### PR TITLE
Prevent rereplication collection operations

### DIFF
--- a/java/src/org/exist/jms/replication/publish/ReplicationTrigger.java
+++ b/java/src/org/exist/jms/replication/publish/ReplicationTrigger.java
@@ -249,6 +249,7 @@ public class ReplicationTrigger extends SAXTrigger implements DocumentTrigger, C
 
         if (isJMSOrigin(transaction)) {
             LOGGER.info(String.format(BLOCKED_MESSAGE, collection.getURI().toString()));
+            return;
         }
 
         // Create Message
@@ -278,6 +279,7 @@ public class ReplicationTrigger extends SAXTrigger implements DocumentTrigger, C
 
         if (isJMSOrigin(txn)) {
             LOGGER.info(String.format(BLOCKED_MESSAGE, collection.getURI().toString()));
+            return;
         }
 
         // Create Message
@@ -303,6 +305,7 @@ public class ReplicationTrigger extends SAXTrigger implements DocumentTrigger, C
 
         if (isJMSOrigin(transaction)) {
             LOGGER.info(String.format(BLOCKED_MESSAGE, collection.getURI().toString()));
+            return;
         }
 
         // Create Message


### PR DESCRIPTION
Also for collections re-replication should be prevented by checking t the origin on an transaction.
