### PR TITLE
Undo group and account creation

### DIFF
--- a/java/src/org/exist/jms/replication/subscribe/ReplicationJmsListener.java
+++ b/java/src/org/exist/jms/replication/subscribe/ReplicationJmsListener.java
@@ -329,8 +329,8 @@ public class ReplicationJmsListener extends eXistMessagingListener {
         }
 
         // Get OWNER and Group
-        final Optional<String> groupName = getOrCreateGroupName(metaData);
         final Optional<String> userName = getOrCreateUserName(metaData);
+        final Optional<String> groupName = getOrCreateGroupName(metaData);
 
         // Get MIME_TYPE
         final String mimeType = getMimeType(metaData, mime.getName());
@@ -658,6 +658,7 @@ public class ReplicationJmsListener extends eXistMessagingListener {
         // Get OWNER/GROUP/MODE
         final Optional<String> userName = getOrCreateUserName(metaData);
         final Optional<String> groupName = getOrCreateGroupName(metaData);
+
         final Optional<Integer> mode = getMode(metaData);
         final Optional<Long> createTime = getCreationTime(metaData);
 
@@ -868,6 +869,7 @@ public class ReplicationJmsListener extends eXistMessagingListener {
         // Get OWNER/GROUP/MODE
         final Optional<String> userName = getOrCreateUserName(metaData);
         final Optional<String> groupName = getOrCreateGroupName(metaData);
+
         final Optional<Integer> mode = getMode(metaData);
 
         final Optional<Long> created = getCreationTime(metaData);
@@ -939,19 +941,19 @@ public class ReplicationJmsListener extends eXistMessagingListener {
         if (account == null) {
             LOG.error(String.format("Username %s does not exist.", userName));
 
-            final Account user = new UserAider(userName);
-            try {
-                securityManager.addAccount(user);
-                account = user;
-            } catch (PermissionDeniedException | EXistException e) {
-                LOG.error(String.format("Unable to create user %s. Fall back to default.", userName));
-            }
-
-
-        }
-
-        // Fallback
-        if (account == null) {
+//            final Account user = new UserAider(userName);
+//            try {
+//                securityManager.addAccount(user);
+//                account = user;
+//            } catch (PermissionDeniedException | EXistException e) {
+//                LOG.error(String.format("Unable to create user %s. Fall back to default. %s", userName,e.getMessage()));
+//            }
+//
+//
+//        }
+//
+//        // Fallback
+//        if (account == null) {
             account = securityManager.getSystemSubject();
         }
 
@@ -975,19 +977,19 @@ public class ReplicationJmsListener extends eXistMessagingListener {
 
         Group group = securityManager.getGroup(groupName);
         if (group == null) {
-            LOG.info(String.format("Group %s does not exist. Will be created.", groupName));
-
-            try {
-                Group newGroup = new GroupAider(groupName);
-                securityManager.addGroup(newGroup);
-                group = newGroup;
-            } catch (PermissionDeniedException | EXistException e) {
-                LOG.error(String.format("Unable to create group %s. Fall back to default.", groupName));
-            }
-        }
-
-        // Fallback
-        if (group == null) {
+            LOG.info(String.format("Group %s does not exist.", groupName));
+//
+//            try {
+//                Group newGroup = new GroupAider(groupName);
+//                securityManager.addGroup(newGroup);
+//                group = newGroup;
+//            } catch (PermissionDeniedException | EXistException e) {
+//                LOG.error(String.format("Unable to create group %s. Fall back to default. %s", groupName, e.getMessage()));
+//            }
+//        }
+//
+//        // Fallback
+//        if (group == null) {
             group = securityManager.getSystemSubject().getDefaultGroup();
         }
 

--- a/java/src/org/exist/jms/replication/subscribe/UserGroupHelper.java
+++ b/java/src/org/exist/jms/replication/subscribe/UserGroupHelper.java
@@ -1,0 +1,100 @@
+package org.exist.jms.replication.subscribe;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.EXistException;
+import org.exist.jms.replication.shared.MessageHelper;
+import org.exist.security.Account;
+import org.exist.security.Group;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Created by wessels on 11/9/16.
+ */
+public class UserGroupHelper {
+
+    private final static Logger LOG = LogManager.getLogger();
+    String groupName;
+    String userName;
+
+    void process(final org.exist.security.SecurityManager securityManager, final Map<String, Object> metaData) {
+
+        String inputUserName = null;
+        Object prop = metaData.get(MessageHelper.EXIST_RESOURCE_OWNER);
+        if (prop != null && prop instanceof String) {
+            inputUserName = (String) prop;
+        } else {
+            LOG.debug("No username provided");
+            return;
+        }
+
+
+        String inputGroupName = null;
+        prop = metaData.get(MessageHelper.EXIST_RESOURCE_GROUP);
+        if (prop != null && prop instanceof String) {
+            inputGroupName = (String) prop;
+        } else {
+            LOG.debug("No groupname provided");
+            return;
+        }
+
+        // check group first
+        Group group = securityManager.getGroup(inputGroupName);
+        if (group == null) {
+            LOG.info(String.format("Group %s does not exist. Will be created.", inputGroupName));
+
+            try {
+                Group newGroup = new GroupAider(inputGroupName);
+                securityManager.addGroup(newGroup);
+                group = newGroup;
+            } catch (PermissionDeniedException | EXistException e) {
+                LOG.error(String.format("Unable to create group %s. Fall back to default. %s", inputGroupName, e.getMessage()));
+            }
+
+            // Fallback
+            if (group == null) {
+                group = securityManager.getSystemSubject().getDefaultGroup();
+            }
+
+            groupName = group.getName();
+        }
+
+
+        // then handle user
+        Account account = securityManager.getAccount(inputUserName);
+        if (account == null) {
+            LOG.error(String.format("Username %s does not exist.", inputUserName));
+
+            final Account user = new UserAider(inputUserName, group);
+            try {
+                securityManager.addAccount(user);
+                account = user;
+            } catch (PermissionDeniedException | EXistException e) {
+                LOG.error(String.format("Unable to create user %s. Fall back to default. %s", inputUserName, e.getMessage()));
+            }
+
+        }
+
+        // Fallback
+        if (account == null) {
+            account = securityManager.getSystemSubject();
+        }
+
+        userName = account.getName();
+
+
+    }
+
+    Optional<String> getGroupName() {
+        return Optional.ofNullable(groupName);
+    }
+
+    Optional<String> getUserName() {
+        return Optional.ofNullable(userName);
+    }
+}


### PR DESCRIPTION
sorry guys The adhoc user/group ration does not work....

```
2016-09-11 18:08:59,220 [ActiveMQ Session Task-1] ERROR (ReplicationJmsListener.java [onMessage]:182) - Broker was not obtained for thread 'Thread[ActiveMQ Session Task-1,7,main]'.

java.lang.RuntimeException: Broker was not obtained for thread 'Thread[ActiveMQ Session Task-1,7,main]'.

        at org.exist.storage.BrokerPool.getActiveBroker(BrokerPool.java:1534) ~[exist.jar:?]
        at org.exist.security.AbstractAccount.addGroup(AbstractAccount.java:116) ~[exist.jar:?]
        at org.exist.security.AbstractAccount.addGroup(AbstractAccount.java:92) ~[exist.jar:?]
        at org.exist.security.internal.AccountImpl.instantiate(AccountImpl.java:192) ~[exist.jar:?]
        at org.exist.security.internal.AccountImpl.<init>(AccountImpl.java:157) ~[exist.jar:?]
        at org.exist.security.internal.SecurityManagerImpl.addAccount(SecurityManagerImpl.java:603) ~[exist.jar:?]
        at org.exist.jms.replication.subscribe.UserGroupHelper.process(UserGroupHelper.java:75) ~[exist-messaging-replication-0.9.11.jar:?]
        at org.exist.jms.replication.subscribe.ReplicationJmsListener.createUpdateDocument(ReplicationJmsListener.java:333) ~[exist-messaging-replication-0.9.11.jar:?]
        at org.exist.jms.replication.subscribe.ReplicationJmsListener.handleDocument(ReplicationJmsListener.java:249) ~[exist-messaging-replication-0.9.11.jar:?]
        at org.exist.jms.replication.subscribe.ReplicationJmsListener.onMessage(ReplicationJmsListener.java:153) [exist-messaging-replication-0.9.11.jar:?]
        at org.apache.activemq.ActiveMQMessageConsumer.dispatch(ActiveMQMessageConsumer.java:1401) [activemq-client-5.14.0.jar:5.14.0]
        at org.apache.activemq.ActiveMQSessionExecutor.dispatch(ActiveMQSessionExecutor.java:131) [activemq-client-5.14.0.jar:5.14.0]
        at org.apache.activemq.ActiveMQSessionExecutor.iterate(ActiveMQSessionExecutor.java:202) [activemq-client-5.14.0.jar:5.14.0]
        at org.apache.activemq.thread.PooledTaskRunner.runTask(PooledTaskRunner.java:133) [activemq-client-5.14.0.jar:5.14.0]
        at org.apache.activemq.thread.PooledTaskRunner$1.run(PooledTaskRunner.java:48) [activemq-client-5.14.0.jar:5.14.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_101]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_101]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]

```
